### PR TITLE
Revert changes in env yamls

### DIFF
--- a/envs/TissueSplit.yaml
+++ b/envs/TissueSplit.yaml
@@ -1,7 +1,9 @@
 name: tissueSplit
+
 channels:
   - conda-forge
   - bioconda
+
 dependencies:
   - r-seurat>=4.3.0
   - r-r.utils

--- a/envs/UMAPplot.yaml
+++ b/envs/UMAPplot.yaml
@@ -1,6 +1,7 @@
 name: UMAP_plot
 channels: 
   - conda-forge
+
 dependencies:
   - r-seurat>=4.3.0
   - r-ggplot2

--- a/envs/createSeuratObject.yaml
+++ b/envs/createSeuratObject.yaml
@@ -1,7 +1,9 @@
 name: SeuratObject
+
 channels: 
   - conda-forge
-  - bioconda 
+  - bioconda
+
 dependencies:
   - r-seurat>=4.3.0
   - r-plyr

--- a/envs/refgen.yaml
+++ b/envs/refgen.yaml
@@ -1,7 +1,9 @@
 name: ref_gen
+
 channels: 
   - conda-forge
-  - bioconda 
+  - bioconda
+
 dependencies:
   - bioconductor-sparsematrixstats
   - r-seurat>=4.3.0

--- a/envs/scONTO.yaml
+++ b/envs/scONTO.yaml
@@ -2,6 +2,7 @@ name: scONTO
 channels: 
   - conda-forge
   - bioconda
+
 dependencies:
   - r-devtools
   - r-seurat>=4.3.0


### PR DESCRIPTION
Add lines back in env yaml files to avoid that snakemake recreates the  Conda environments as this is problematic for packages installed from GitHub